### PR TITLE
Fix broken headless mode due to some new Chrome options since v59

### DIFF
--- a/helpers/helpers.py
+++ b/helpers/helpers.py
@@ -9,7 +9,7 @@ def find_element(driver, by_type, locator):
         return WebDriverWait(driver, delay).until(EC.presence_of_element_located((by_type, locator)))
 
     except TimeoutException:
-        print "element {} was not found".format(locator)
+        print("element {} was not found".format(locator))
 
 
 def click(driver, by_type, locator):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,10 +20,13 @@ def chrome(request):
     chrome_options = webdriver.ChromeOptions()
     if headless == "true":
         # Set headless flag to true
-        chrome_options.add_argument("headless")
+        chrome_options.add_argument("--headless")
+        chrome_options.add_argument("--no-proxy-server")
+        chrome_options.add_argument("--proxy-server='direct://'")
+        chrome_options.add_argument("--proxy-bypass-list=*")
 
     # Initiate Chrome
-    browser = webdriver.Chrome(chrome_options=chrome_options)
+    browser = webdriver.Chrome(options=chrome_options)
 
     yield browser
 

--- a/tests/test_websites_titles.py
+++ b/tests/test_websites_titles.py
@@ -7,7 +7,7 @@ from selenium.webdriver.common.by import By
     ("http://www.brandlovescore.com/", "Brand Love Score"),
     ("https://www.polygon.com/", "Polygon"),
     ("https://thenextweb.com/", "TNW"),
-    ("https://www.blazemeter.com/", "JMeter and Performance Testing for DevOps | BlazeMeter"),
+    ("https://www.blazemeter.com/", "BlazeMeter"),
     ("https://www.theverge.com/", "The Verge"),
 ])
 def test_check_website_titles(chrome, url, title):


### PR DESCRIPTION
Now it works perfectly

```

$ pytest.exe -v --headless=true
============================= test session starts =============================
platform win32 -- Python 3.8.0, pytest-5.3.1, py-1.8.0, pluggy-0.13.1 -- c:\users\nvme\appdata\local\programs\python\python38\python.exe
cachedir: .pytest_cache
rootdir: L:\Y_exps_drafts_debugs_logs_exmpls\Y_python_projects\headless_testing
collecting ... collected 12 items

tests/test_smoke.py::test_find_flights[Paris-Buenos Aires] PASSED        [  8%]
tests/test_smoke.py::test_find_flights[Philadelphia-Rome] PASSED         [ 16%]
tests/test_smoke.py::test_find_flights[Boston-London] PASSED             [ 25%]
tests/test_smoke.py::test_find_flights[Portland-Berlin] PASSED           [ 33%]
tests/test_smoke.py::test_find_flights[San Diego-New York] PASSED        [ 41%]
tests/test_smoke.py::test_find_flights[Mexico City-Dublin] PASSED        [ 50%]
tests/test_smoke.py::test_teardown PASSED                                [ 58%]
tests/test_websites_titles.py::test_check_website_titles[http://www.brandlovescore.com/-Brand Love Score] PASSED [ 66%]
tests/test_websites_titles.py::test_check_website_titles[https://www.polygon.com/-Polygon] PASSED [ 75%]
tests/test_websites_titles.py::test_check_website_titles[https://thenextweb.com/-TNW] PASSED [ 83%]
tests/test_websites_titles.py::test_check_website_titles[https://www.blazemeter.com/-BlazeMeter] PASSED [ 91%]
tests/test_websites_titles.py::test_check_website_titles[https://www.theverge.com/-The Verge] PASSED [100%]

======================== 12 passed in 86.55s (0:01:26) ========================
```
